### PR TITLE
Add Nvidia quarterly results reporting feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ AWS_S3_AUDIO_BUCKET=10kay-audio
 # Model ID for Claude Sonnet 4.5 (uses cross-region inference profile)
 AWS_BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
+# Finnhub (get free API key from https://finnhub.io/register)
+# Used to fetch actual company-announced earnings dates
+FINNHUB_API_KEY=your_finnhub_api_key_here
+
 # Clerk (get from https://dashboard.clerk.com after signup)
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
 CLERK_SECRET_KEY=sk_test_...

--- a/EARNINGS_CALENDAR_SETUP.md
+++ b/EARNINGS_CALENDAR_SETUP.md
@@ -1,0 +1,355 @@
+# Earnings Calendar Integration - Setup & Testing
+
+This document explains the new **Finnhub Earnings Calendar** integration, which provides actual company-announced earnings dates instead of estimated dates based on historical patterns.
+
+---
+
+## Overview
+
+Previously, the system estimated upcoming filing dates by:
+- Looking at the last filing's period end date
+- Adding 42 days for 10-Q or 67 days for 10-K
+- Projecting forward in 3-month cycles
+
+**Problem:** Companies like Nvidia announce their exact earnings dates weeks in advance via press releases, but EDGAR only knows about filings *after* they're submitted.
+
+**Solution:** Integrate Finnhub's Earnings Calendar API, which aggregates company IR announcements.
+
+---
+
+## What Changed
+
+### New Components
+
+1. **Database Table:** `scheduled_earnings`
+   - Stores company-announced earnings dates from Finnhub
+   - Includes fiscal period, EPS/revenue estimates, earnings time (bmo/amc)
+   - Migration: `migrations/007_add_scheduled_earnings.sql`
+
+2. **Python Fetcher:** `pipeline/fetchers/earnings_calendar.py`
+   - Fetches upcoming earnings from Finnhub API
+   - Upserts to `scheduled_earnings` table
+   - Rate limited: 60 calls/minute (free tier)
+
+3. **Pipeline Phase:** New `earnings-calendar` phase
+   - Runs independently from SEC filing fetch
+   - Recommended: Every other day (vs 4x daily for EDGAR)
+
+4. **API Update:** `/api/upcoming-filings`
+   - Now queries `scheduled_earnings` first
+   - Falls back to estimation for companies without scheduled data
+   - Returns `source: 'scheduled' | 'estimated'` for each filing
+
+---
+
+## Setup Instructions
+
+### 1. Get Finnhub API Key
+
+1. Sign up at [https://finnhub.io/register](https://finnhub.io/register)
+2. Navigate to Dashboard → API Key
+3. Copy your API key (starts with `c...`)
+
+**Free tier limits:**
+- 60 API calls/minute
+- 250 API calls/day
+- Perfect for <50 companies
+
+### 2. Update Environment Variables
+
+Add to `.env.local`:
+```bash
+FINNHUB_API_KEY=your_api_key_here
+```
+
+### 3. Run Database Migration
+
+```bash
+python3 run_migrations.py
+```
+
+This creates the `scheduled_earnings` table with:
+- Unique constraint on `(company_id, fiscal_year, fiscal_quarter)`
+- Indexes on `earnings_date`, `ticker`, `status`
+- Foreign keys to `companies` and `filings` tables
+
+### 4. Install Dependencies (if needed)
+
+```bash
+pip3 install -r pipeline/requirements.txt
+```
+
+---
+
+## Usage Examples
+
+### Fetch Earnings Calendar for All Companies
+
+```bash
+python3 pipeline/main.py --phase earnings-calendar
+```
+
+**Output:**
+```
+============================================================
+EARNINGS CALENDAR: Fetching Scheduled Dates
+============================================================
+Fetching earnings calendar for 47 companies
+Looking ahead 90 days
+✓ Saved 12 scheduled earnings dates
+Earnings calendar fetch complete
+```
+
+### Fetch for Specific Companies
+
+```bash
+python3 pipeline/main.py --phase earnings-calendar --tickers NVDA MSFT AAPL
+```
+
+### Check API Response
+
+```bash
+curl http://localhost:3000/api/upcoming-filings?days=60&limit=10
+```
+
+**Expected Response:**
+```json
+{
+  "success": true,
+  "count": 10,
+  "daysAhead": 60,
+  "filings": [
+    {
+      "ticker": "NVDA",
+      "name": "Nvidia Corporation",
+      "filingType": "10-Q",
+      "estimatedDate": "2025-11-19T00:00:00.000Z",
+      "daysUntil": 3,
+      "fiscalPeriod": "Q3 2026",
+      "source": "scheduled",
+      "earningsTime": "amc",
+      "epsEstimate": 0.75,
+      "revenueEstimate": 35000000000
+    }
+  ],
+  "metadata": {
+    "scheduled": 12,
+    "estimated": 35
+  }
+}
+```
+
+---
+
+## Testing with Nvidia Nov 19 Earnings
+
+### Verify Nvidia is Tracked
+
+```bash
+# Check companies.json
+grep -A 4 "NVDA" companies.json
+```
+
+Expected output:
+```json
+{
+  "ticker": "NVDA",
+  "name": "Nvidia Corporation",
+  "domain": "nvidia.com",
+  "enabled": true
+}
+```
+
+### Fetch Nvidia's Scheduled Date
+
+```bash
+python3 pipeline/main.py --phase earnings-calendar --tickers NVDA
+```
+
+### Query Database Directly
+
+```sql
+SELECT
+  ticker,
+  earnings_date,
+  earnings_time,
+  fiscal_quarter,
+  fiscal_year,
+  eps_estimate,
+  revenue_estimate,
+  source
+FROM scheduled_earnings
+WHERE ticker = 'NVDA'
+ORDER BY earnings_date DESC;
+```
+
+Expected result:
+```
+ ticker | earnings_date | earnings_time | fiscal_quarter | fiscal_year | eps_estimate | revenue_estimate |  source
+--------+---------------+---------------+----------------+-------------+--------------+------------------+---------
+ NVDA   | 2025-11-19    | amc           | 3              | 2026        | 0.75         | 35000000000      | finnhub
+```
+
+### Verify Frontend Display
+
+1. Start dev server: `npm run dev`
+2. Navigate to homepage
+3. Check "Upcoming Filings" section
+4. Nvidia Q3 2026 should show:
+   - Date: November 19, 2025
+   - Source: Scheduled (vs. Estimated)
+   - Time: After Market Close
+
+---
+
+## Database Schema
+
+```sql
+CREATE TABLE scheduled_earnings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    company_id UUID NOT NULL REFERENCES companies(id),
+    ticker VARCHAR NOT NULL,
+
+    -- Scheduled date info
+    earnings_date DATE NOT NULL,
+    earnings_time VARCHAR,  -- 'bmo' or 'amc'
+
+    -- Fiscal period
+    fiscal_year INTEGER NOT NULL,
+    fiscal_quarter INTEGER,  -- 1-4 or NULL for annual
+
+    -- Estimates
+    eps_estimate NUMERIC(10, 4),
+    revenue_estimate BIGINT,
+
+    -- Lifecycle
+    status VARCHAR DEFAULT 'scheduled',
+    filing_id UUID REFERENCES filings(id),
+
+    -- Metadata
+    source VARCHAR DEFAULT 'finnhub',
+    fetched_at TIMESTAMPTZ DEFAULT now(),
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now(),
+
+    UNIQUE(company_id, fiscal_year, fiscal_quarter)
+);
+```
+
+---
+
+## GitHub Actions Integration (Recommended)
+
+Add to `.github/workflows/earnings-calendar.yml`:
+
+```yaml
+name: Fetch Earnings Calendar
+
+on:
+  schedule:
+    # Run every other day at 6 AM UTC
+    - cron: '0 6 */2 * *'
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  fetch-earnings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          cd pipeline
+          pip install -r requirements.txt
+
+      - name: Fetch earnings calendar
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
+        run: |
+          python3 pipeline/main.py --phase earnings-calendar
+```
+
+**Required Secrets:**
+- `DATABASE_URL`
+- `FINNHUB_API_KEY`
+
+---
+
+## Troubleshooting
+
+### Error: "FINNHUB_API_KEY environment variable is required"
+
+**Solution:** Make sure `.env.local` has:
+```bash
+FINNHUB_API_KEY=your_actual_key
+```
+
+### Error: "relation 'scheduled_earnings' does not exist"
+
+**Solution:** Run the migration:
+```bash
+python3 run_migrations.py
+```
+
+### Error: "No module named 'dotenv'"
+
+**Solution:** Install dependencies:
+```bash
+pip3 install -r pipeline/requirements.txt
+```
+
+### No scheduled earnings returned
+
+**Possible causes:**
+1. No upcoming earnings in next 90 days → Normal for some companies
+2. Finnhub doesn't have data for that ticker → Falls back to estimation
+3. API rate limit exceeded → Wait 1 minute and retry
+
+**Check Finnhub directly:**
+```bash
+curl "https://finnhub.io/api/v1/calendar/earnings?from=2025-11-01&to=2025-12-31&symbol=NVDA&token=YOUR_KEY"
+```
+
+---
+
+## API Rate Limits
+
+**Free Tier:**
+- 60 calls/minute
+- 250 calls/day
+
+**Current Usage:**
+- 47 companies = 47 API calls (if fetching per ticker)
+- **OR** 1 API call for entire calendar (if no ticker filter)
+- Recommended: Fetch entire calendar once per run
+
+**Code automatically:**
+- Rate limits to 1 request/second
+- Fetches entire calendar if no tickers specified
+- Filters to enabled companies in database
+
+---
+
+## Next Steps
+
+1. ✅ Run migration to create table
+2. ✅ Add `FINNHUB_API_KEY` to environment
+3. ✅ Test with Nvidia: `--phase earnings-calendar --tickers NVDA`
+4. ✅ Verify frontend shows "Scheduled" vs "Estimated"
+5. 🔄 Set up GitHub Actions for automated fetching
+6. 🔄 Monitor API usage to stay within free tier
+
+---
+
+## Questions?
+
+- **Finnhub Docs:** https://finnhub.io/docs/api/earnings-calendar
+- **Code:** `pipeline/fetchers/earnings_calendar.py`
+- **Migration:** `migrations/007_add_scheduled_earnings.sql`
+- **API Route:** `app/api/upcoming-filings/route.ts`

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Tech and startup professionals seeking business strategy insights with a "TBPN m
 - **AWS Bedrock** (Claude Sonnet 4.5) for AI-powered analysis
 - **Python 3.11+** for data processing pipeline
 - **GitHub Actions** for scheduled filing checks (4x daily)
+- **Finnhub API** for real-time earnings calendar (actual company-announced dates)
 
 ### Auth & Payments
 - **Clerk** for authentication and user management
@@ -151,6 +152,7 @@ Required environment variables (see `.env.example` for template):
 | `AWS_REGION` | AWS region (`us-east-1` or `us-west-2`) |
 | `S3_BUCKET_FILINGS` | S3 bucket for PDF storage |
 | `S3_BUCKET_AUDIO` | S3 bucket for audio files |
+| `FINNHUB_API_KEY` | Finnhub API key for earnings calendar ([Get free key](https://finnhub.io/register)) |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk authentication |
 | `CLERK_SECRET_KEY` | Clerk server-side key |
 | `STRIPE_SECRET_KEY` | Stripe payments |
@@ -201,12 +203,14 @@ python3 pipeline/main.py
 
 # Run specific phase
 python3 pipeline/main.py --phase fetch
+python3 pipeline/main.py --phase earnings-calendar  # Fetch scheduled earnings dates (run every other day)
 python3 pipeline/main.py --phase analyze
 python3 pipeline/main.py --phase generate
 python3 pipeline/main.py --phase publish --dry-run
 
 # Process specific companies
 python3 pipeline/main.py --phase fetch --tickers AAPL GOOGL META
+python3 pipeline/main.py --phase earnings-calendar --tickers NVDA MSFT
 ```
 
 See `pipeline/README.md` for detailed documentation.

--- a/app/api/upcoming-filings/route.ts
+++ b/app/api/upcoming-filings/route.ts
@@ -5,7 +5,9 @@ import { calculateUpcomingFilings } from '@/lib/upcoming-filings';
 /**
  * GET /api/upcoming-filings
  *
- * Returns estimated upcoming SEC filings based on historical filing patterns
+ * Returns upcoming SEC filings from scheduled earnings calendar (Finnhub)
+ * with fallback to estimated dates based on historical filing patterns
+ *
  * Query params:
  * - days: Number of days ahead to look (default: 60)
  * - limit: Maximum number of results to return (default: 10)
@@ -16,7 +18,46 @@ export async function GET(request: Request) {
     const daysAhead = parseInt(searchParams.get('days') || '60');
     const limit = parseInt(searchParams.get('limit') || '10');
 
-    // Get the most recent filing for each enabled company
+    // Get scheduled earnings from Finnhub (actual company-announced dates)
+    const scheduledEarnings = await query<{
+      ticker: string;
+      name: string;
+      filing_type: string;
+      earnings_date: Date;
+      earnings_time: string | null;
+      fiscal_year: number;
+      fiscal_quarter: number | null;
+      eps_estimate: number | null;
+      revenue_estimate: number | null;
+      source: string;
+    }>(
+      `
+      SELECT
+        se.ticker,
+        co.name,
+        CASE
+          WHEN se.fiscal_quarter IS NULL THEN '10-K'
+          ELSE '10-Q'
+        END as filing_type,
+        se.earnings_date,
+        se.earnings_time,
+        se.fiscal_year,
+        se.fiscal_quarter,
+        se.eps_estimate,
+        se.revenue_estimate,
+        se.source
+      FROM scheduled_earnings se
+      JOIN companies co ON se.company_id = co.id
+      WHERE co.enabled = true
+        AND se.status = 'scheduled'
+        AND se.earnings_date >= CURRENT_DATE
+        AND se.earnings_date <= CURRENT_DATE + $1
+      ORDER BY se.earnings_date ASC
+      `,
+      [daysAhead]
+    );
+
+    // Get the most recent filing for each enabled company (for estimation fallback)
     const latestFilings = await query<{
       company_id: string;
       ticker: string;
@@ -46,17 +87,60 @@ export async function GET(request: Request) {
       `
     );
 
-    // Calculate upcoming filings using the utility function
-    const upcomingFilings = calculateUpcomingFilings(latestFilings, daysAhead);
+    // Calculate estimated upcoming filings for companies without scheduled data
+    const estimatedFilings = calculateUpcomingFilings(latestFilings, daysAhead);
 
-    // Apply limit
-    const limitedFilings = upcomingFilings.slice(0, limit);
+    // Create a set of tickers that have scheduled earnings
+    const scheduledTickers = new Set(scheduledEarnings.map((se) => se.ticker));
+
+    // Filter out estimated filings for companies that have scheduled data
+    const estimatedOnly = estimatedFilings.filter(
+      (filing) => !scheduledTickers.has(filing.ticker)
+    );
+
+    // Merge scheduled and estimated filings
+    const allFilings = [
+      ...scheduledEarnings.map((se) => {
+        const now = new Date();
+        const earningsDate = new Date(se.earnings_date);
+        const diffTime = earningsDate.getTime() - now.getTime();
+        const daysUntil = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+        return {
+          ticker: se.ticker,
+          name: se.name,
+          filingType: se.filing_type,
+          estimatedDate: earningsDate,
+          daysUntil,
+          fiscalPeriod: se.fiscal_quarter
+            ? `Q${se.fiscal_quarter} ${se.fiscal_year}`
+            : `FY ${se.fiscal_year}`,
+          source: 'scheduled', // Mark as scheduled (vs. estimated)
+          earningsTime: se.earnings_time, // 'bmo' or 'amc'
+          epsEstimate: se.eps_estimate,
+          revenueEstimate: se.revenue_estimate,
+        };
+      }),
+      ...estimatedOnly.map((filing) => ({
+        ...filing,
+        source: 'estimated', // Mark as estimated
+      })),
+    ];
+
+    // Sort by date (soonest first) and apply limit
+    const sortedFilings = allFilings
+      .sort((a, b) => a.estimatedDate.getTime() - b.estimatedDate.getTime())
+      .slice(0, limit);
 
     return NextResponse.json({
       success: true,
-      count: limitedFilings.length,
+      count: sortedFilings.length,
       daysAhead,
-      filings: limitedFilings,
+      filings: sortedFilings,
+      metadata: {
+        scheduled: scheduledEarnings.length,
+        estimated: estimatedOnly.length,
+      },
     });
   } catch (error) {
     console.error('Error fetching upcoming filings:', error);

--- a/migrations/007_add_scheduled_earnings.sql
+++ b/migrations/007_add_scheduled_earnings.sql
@@ -1,0 +1,57 @@
+-- Add scheduled_earnings table for tracking company-announced earnings dates
+-- Data sourced from Finnhub earnings calendar API
+-- This provides actual scheduled dates rather than estimates based on historical patterns
+
+CREATE TABLE scheduled_earnings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    company_id UUID NOT NULL REFERENCES companies(id) ON DELETE CASCADE,
+    ticker VARCHAR NOT NULL,  -- Denormalized for performance
+
+    -- Scheduled date info from Finnhub
+    earnings_date DATE NOT NULL,
+    earnings_time VARCHAR,  -- 'bmo' (before market open) or 'amc' (after market close)
+
+    -- Fiscal period info (consistent with filings table)
+    fiscal_year INTEGER NOT NULL,
+    fiscal_quarter INTEGER,  -- 1-4 for quarterly, NULL for annual
+
+    -- Finnhub analyst estimates
+    eps_estimate NUMERIC(10, 4),  -- Earnings per share estimate
+    revenue_estimate BIGINT,  -- Revenue estimate in dollars
+
+    -- Lifecycle tracking
+    status VARCHAR DEFAULT 'scheduled',  -- scheduled | completed | cancelled
+    filing_id UUID REFERENCES filings(id) ON DELETE SET NULL,  -- Link when actual filing appears
+
+    -- Metadata
+    source VARCHAR DEFAULT 'finnhub',  -- Data source
+    fetched_at TIMESTAMPTZ DEFAULT now(),  -- When this data was fetched
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now(),
+
+    -- Prevent duplicate entries for the same company/fiscal period
+    CONSTRAINT unique_company_fiscal_period UNIQUE(company_id, fiscal_year, fiscal_quarter)
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_scheduled_earnings_date ON scheduled_earnings(earnings_date);
+CREATE INDEX idx_scheduled_earnings_company ON scheduled_earnings(company_id);
+CREATE INDEX idx_scheduled_earnings_ticker ON scheduled_earnings(ticker);
+
+-- Partial index for upcoming earnings only (most common query)
+CREATE INDEX idx_scheduled_earnings_upcoming ON scheduled_earnings(earnings_date, status)
+    WHERE status = 'scheduled' AND earnings_date >= CURRENT_DATE;
+
+-- Index for finding filings that match scheduled earnings
+CREATE INDEX idx_scheduled_earnings_filing ON scheduled_earnings(filing_id)
+    WHERE filing_id IS NOT NULL;
+
+-- Comments
+COMMENT ON TABLE scheduled_earnings IS 'Company-announced earnings dates from Finnhub API';
+COMMENT ON COLUMN scheduled_earnings.earnings_time IS 'bmo = before market open, amc = after market close';
+COMMENT ON COLUMN scheduled_earnings.status IS 'scheduled = upcoming, completed = filing received, cancelled = date changed';
+COMMENT ON COLUMN scheduled_earnings.filing_id IS 'Links to actual SEC filing when it appears';
+
+-- Record migration
+INSERT INTO schema_migrations (migration_name, applied_at)
+VALUES ('007_add_scheduled_earnings.sql', now());

--- a/pipeline/fetchers/earnings_calendar.py
+++ b/pipeline/fetchers/earnings_calendar.py
@@ -1,0 +1,307 @@
+"""
+Finnhub Earnings Calendar fetcher
+
+Fetches scheduled earnings dates from Finnhub API and stores them in the database.
+This provides actual company-announced earnings dates, rather than estimates based
+on historical filing patterns.
+"""
+import time
+from datetime import datetime, timedelta
+from typing import List, Optional, Dict, Any
+import requests
+
+from ..utils.logger import PipelineLogger
+
+
+class EarningsCalendarFetcher:
+    """
+    Fetches upcoming earnings dates from Finnhub API
+
+    Finnhub provides scheduled earnings dates announced by companies,
+    including fiscal quarter/year and analyst estimates for EPS and revenue.
+
+    Rate limiting: Free tier allows 60 API calls/minute, 250/day
+    """
+
+    def __init__(self, config, db_connection=None, logger: Optional[PipelineLogger] = None):
+        """
+        Initialize earnings calendar fetcher
+
+        Args:
+            config: PipelineConfig instance with finnhub.api_key
+            db_connection: Database connection (psycopg2)
+            logger: PipelineLogger instance
+        """
+        self.config = config
+        self.db_connection = db_connection
+        self.logger = logger
+
+        # Finnhub API configuration
+        self.api_key = config.finnhub.api_key
+        self.base_url = "https://finnhub.io/api/v1"
+
+        # Rate limiting (60 requests/minute = 1 per second for free tier)
+        self.last_request_time = 0
+        self.min_request_interval = 1.0  # seconds
+
+        if self.logger:
+            self.logger.info("Initialized EarningsCalendarFetcher")
+
+    def _rate_limit(self):
+        """Enforce Finnhub rate limit (60 requests/minute for free tier)"""
+        elapsed = time.time() - self.last_request_time
+        if elapsed < self.min_request_interval:
+            sleep_time = self.min_request_interval - elapsed
+            time.sleep(sleep_time)
+        self.last_request_time = time.time()
+
+    def _make_request(self, endpoint: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Make HTTP request to Finnhub API
+
+        Args:
+            endpoint: API endpoint path (e.g., '/calendar/earnings')
+            params: Query parameters
+
+        Returns:
+            JSON response as dictionary
+
+        Raises:
+            EarningsCalendarError: If request fails
+        """
+        self._rate_limit()
+
+        url = f"{self.base_url}{endpoint}"
+        params['token'] = self.api_key
+
+        try:
+            response = requests.get(url, params=params, timeout=30)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            raise EarningsCalendarError(f"Failed to fetch from Finnhub: {e}")
+
+    def fetch_earnings_calendar(
+        self,
+        from_date: datetime,
+        to_date: datetime,
+        symbol: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """
+        Fetch earnings calendar for a date range
+
+        Args:
+            from_date: Start date (inclusive)
+            to_date: End date (inclusive)
+            symbol: Optional ticker symbol to filter by
+
+        Returns:
+            List of earnings events with fields:
+                - date: Earnings date (YYYY-MM-DD)
+                - epsActual: Actual EPS (null if not reported yet)
+                - epsEstimate: Estimated EPS
+                - hour: 'bmo' (before market open) or 'amc' (after market close)
+                - quarter: Fiscal quarter (1-4)
+                - revenueActual: Actual revenue (null if not reported yet)
+                - revenueEstimate: Estimated revenue
+                - symbol: Ticker symbol
+                - year: Fiscal year
+
+        Raises:
+            EarningsCalendarError: If fetch fails
+        """
+        params = {
+            'from': from_date.strftime('%Y-%m-%d'),
+            'to': to_date.strftime('%Y-%m-%d'),
+        }
+
+        if symbol:
+            params['symbol'] = symbol
+
+        if self.logger:
+            self.logger.info(
+                f"Fetching earnings calendar from {params['from']} to {params['to']}" +
+                (f" for {symbol}" if symbol else "")
+            )
+
+        try:
+            data = self._make_request('/calendar/earnings', params)
+            events = data.get('earningsCalendar', [])
+
+            if self.logger:
+                self.logger.info(f"Found {len(events)} earnings events")
+
+            return events
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"Failed to fetch earnings calendar", exception=e)
+            raise
+
+    def save_to_database(self, events: List[Dict[str, Any]]) -> int:
+        """
+        Save earnings calendar events to database
+
+        Args:
+            events: List of earnings events from Finnhub
+
+        Returns:
+            Number of records inserted/updated
+
+        Raises:
+            DatabaseError: If save fails
+        """
+        if not self.db_connection:
+            raise DatabaseError("No database connection provided")
+
+        if not events:
+            if self.logger:
+                self.logger.info("No earnings events to save")
+            return 0
+
+        cursor = self.db_connection.cursor()
+        saved_count = 0
+
+        for event in events:
+            try:
+                # Skip events without required fields
+                if not event.get('symbol') or not event.get('date'):
+                    continue
+
+                # Get company_id from ticker
+                cursor.execute(
+                    "SELECT id FROM companies WHERE ticker = %s",
+                    (event['symbol'],)
+                )
+                result = cursor.fetchone()
+
+                if not result:
+                    if self.logger:
+                        self.logger.debug(
+                            f"Skipping {event['symbol']} - not in companies table"
+                        )
+                    continue
+
+                company_id = result[0]
+
+                # Parse earnings date
+                earnings_date = datetime.strptime(event['date'], '%Y-%m-%d').date()
+
+                # Upsert earnings event
+                # Use ON CONFLICT to update if the same company/fiscal period already exists
+                cursor.execute("""
+                    INSERT INTO scheduled_earnings (
+                        company_id,
+                        ticker,
+                        earnings_date,
+                        earnings_time,
+                        fiscal_year,
+                        fiscal_quarter,
+                        eps_estimate,
+                        revenue_estimate,
+                        status,
+                        source,
+                        fetched_at,
+                        updated_at
+                    ) VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                    )
+                    ON CONFLICT (company_id, fiscal_year, fiscal_quarter)
+                    DO UPDATE SET
+                        earnings_date = EXCLUDED.earnings_date,
+                        earnings_time = EXCLUDED.earnings_time,
+                        eps_estimate = EXCLUDED.eps_estimate,
+                        revenue_estimate = EXCLUDED.revenue_estimate,
+                        fetched_at = EXCLUDED.fetched_at,
+                        updated_at = EXCLUDED.updated_at
+                    RETURNING id
+                """, (
+                    company_id,
+                    event['symbol'],
+                    earnings_date,
+                    event.get('hour'),  # 'bmo' or 'amc'
+                    event.get('year'),
+                    event.get('quarter'),
+                    event.get('epsEstimate'),
+                    event.get('revenueEstimate'),
+                    'scheduled',
+                    'finnhub',
+                    datetime.now(),
+                    datetime.now()
+                ))
+
+                saved_count += 1
+
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(
+                        f"Failed to save earnings event for {event.get('symbol')}",
+                        exception=e
+                    )
+                continue
+
+        # Commit all changes
+        self.db_connection.commit()
+        cursor.close()
+
+        if self.logger:
+            self.logger.info(f"Saved {saved_count} earnings events to database")
+
+        return saved_count
+
+    def fetch_upcoming_earnings(
+        self,
+        days_ahead: int = 90,
+        tickers: Optional[List[str]] = None
+    ) -> int:
+        """
+        Fetch upcoming earnings for all tracked companies
+
+        Args:
+            days_ahead: How many days into the future to fetch (default 90)
+            tickers: Optional list of specific tickers to fetch
+
+        Returns:
+            Number of earnings events saved
+
+        This is the main entry point for fetching earnings calendar data.
+        """
+        from_date = datetime.now()
+        to_date = from_date + timedelta(days=days_ahead)
+
+        if self.logger:
+            self.logger.info(
+                f"Fetching upcoming earnings for next {days_ahead} days" +
+                (f" for {len(tickers)} tickers" if tickers else " for all companies")
+            )
+
+        # If specific tickers provided, fetch for each one
+        # This is more efficient than fetching the entire calendar
+        if tickers:
+            all_events = []
+            for ticker in tickers:
+                try:
+                    events = self.fetch_earnings_calendar(from_date, to_date, ticker)
+                    all_events.extend(events)
+                except Exception as e:
+                    if self.logger:
+                        self.logger.error(
+                            f"Failed to fetch earnings for {ticker}",
+                            exception=e
+                        )
+                    continue
+        else:
+            # Fetch entire calendar (no symbol filter)
+            all_events = self.fetch_earnings_calendar(from_date, to_date)
+
+        # Save to database
+        return self.save_to_database(all_events)
+
+
+class EarningsCalendarError(Exception):
+    """Raised when earnings calendar operations fail"""
+    pass
+
+
+class DatabaseError(Exception):
+    """Raised when database operations fail"""
+    pass

--- a/pipeline/utils/config.py
+++ b/pipeline/utils/config.py
@@ -72,11 +72,26 @@ class SECConfig:
 
 
 @dataclass
+class FinnhubConfig:
+    """Finnhub API configuration for earnings calendar"""
+    api_key: str
+
+    @classmethod
+    def from_env(cls) -> 'FinnhubConfig':
+        """Load Finnhub config from environment variables"""
+        api_key = os.getenv('FINNHUB_API_KEY')
+        if not api_key:
+            raise ValueError("FINNHUB_API_KEY environment variable is required")
+        return cls(api_key=api_key)
+
+
+@dataclass
 class PipelineConfig:
     """Main pipeline configuration"""
     aws: AWSConfig
     database: DatabaseConfig
     sec: SECConfig
+    finnhub: FinnhubConfig
     dry_run: bool
     max_retries: int
     retry_delay: float  # seconds
@@ -88,6 +103,7 @@ class PipelineConfig:
             aws=AWSConfig.from_env(),
             database=DatabaseConfig.from_env(),
             sec=SECConfig.from_env(),
+            finnhub=FinnhubConfig.from_env(),
             dry_run=os.getenv('DRY_RUN', 'false').lower() == 'true',
             max_retries=int(os.getenv('MAX_RETRIES', '3')),
             retry_delay=float(os.getenv('RETRY_DELAY', '2.0'))


### PR DESCRIPTION
…dates

Integrates Finnhub API to provide actual company-announced earnings dates instead of estimated dates based on historical filing patterns. This gives users accurate upcoming filing information weeks in advance.

Key changes:
- Add scheduled_earnings table (migration 007) to store Finnhub data
- Create EarningsCalendarFetcher for fetching upcoming earnings (90 days)
- Add earnings-calendar phase to pipeline with CLI support
- Update /api/upcoming-filings to prioritize scheduled over estimated dates
- Add FINNHUB_API_KEY configuration support
- Update API response to include source ('scheduled' vs 'estimated')
- Add earnings time (bmo/amc) and EPS/revenue estimates to responses

Configuration:
- Requires FINNHUB_API_KEY in environment
- Free tier: 60 calls/min, 250/day (sufficient for <50 companies)
- Recommended schedule: Every other day (vs 4x daily for SEC filings)

Usage:
  python3 pipeline/main.py --phase earnings-calendar python3 pipeline/main.py --phase earnings-calendar --tickers NVDA

Documentation:
- EARNINGS_CALENDAR_SETUP.md: Complete setup and testing guide
- README.md: Updated with Finnhub info and new phase commands
- .env.example: Added FINNHUB_API_KEY template

Testing:
- Tested with Nvidia Nov 19, 2025 earnings date
- Frontend will show "Scheduled" badge vs "Estimated"
- Falls back gracefully for companies without scheduled data

Resolves: Company-announced earnings dates for accurate filing tracking