### PR TITLE
Fix API key environment variable naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ AWS_BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
 # Finnhub (get free API key from https://finnhub.io/register)
 # Used to fetch actual company-announced earnings dates
-FINNHUB_API_KEY=your_finnhub_api_key_here
+FINHUB_API_KEY=your_finnhub_api_key_here
 
 # Clerk (get from https://dashboard.clerk.com after signup)
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...

--- a/EARNINGS_CALENDAR_SETUP.md
+++ b/EARNINGS_CALENDAR_SETUP.md
@@ -59,7 +59,7 @@ Previously, the system estimated upcoming filing dates by:
 
 Add to `.env.local`:
 ```bash
-FINNHUB_API_KEY=your_api_key_here
+FINHUB_API_KEY=your_api_key_here
 ```
 
 ### 3. Run Database Migration
@@ -270,24 +270,24 @@ jobs:
       - name: Fetch earnings calendar
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
+          FINHUB_API_KEY: ${{ secrets.FINHUB_API_KEY }}
         run: |
           python3 pipeline/main.py --phase earnings-calendar
 ```
 
 **Required Secrets:**
 - `DATABASE_URL`
-- `FINNHUB_API_KEY`
+- `FINHUB_API_KEY`
 
 ---
 
 ## Troubleshooting
 
-### Error: "FINNHUB_API_KEY environment variable is required"
+### Error: "FINHUB_API_KEY environment variable is required"
 
 **Solution:** Make sure `.env.local` has:
 ```bash
-FINNHUB_API_KEY=your_actual_key
+FINHUB_API_KEY=your_actual_key
 ```
 
 ### Error: "relation 'scheduled_earnings' does not exist"
@@ -339,7 +339,7 @@ curl "https://finnhub.io/api/v1/calendar/earnings?from=2025-11-01&to=2025-12-31&
 ## Next Steps
 
 1. ✅ Run migration to create table
-2. ✅ Add `FINNHUB_API_KEY` to environment
+2. ✅ Add `FINHUB_API_KEY` to environment
 3. ✅ Test with Nvidia: `--phase earnings-calendar --tickers NVDA`
 4. ✅ Verify frontend shows "Scheduled" vs "Estimated"
 5. 🔄 Set up GitHub Actions for automated fetching

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Required environment variables (see `.env.example` for template):
 | `AWS_REGION` | AWS region (`us-east-1` or `us-west-2`) |
 | `S3_BUCKET_FILINGS` | S3 bucket for PDF storage |
 | `S3_BUCKET_AUDIO` | S3 bucket for audio files |
-| `FINNHUB_API_KEY` | Finnhub API key for earnings calendar ([Get free key](https://finnhub.io/register)) |
+| `FINHUB_API_KEY` | Finnhub API key for earnings calendar ([Get free key](https://finnhub.io/register)) |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk authentication |
 | `CLERK_SECRET_KEY` | Clerk server-side key |
 | `STRIPE_SECRET_KEY` | Stripe payments |

--- a/pipeline/utils/config.py
+++ b/pipeline/utils/config.py
@@ -79,9 +79,9 @@ class FinnhubConfig:
     @classmethod
     def from_env(cls) -> 'FinnhubConfig':
         """Load Finnhub config from environment variables"""
-        api_key = os.getenv('FINNHUB_API_KEY')
+        api_key = os.getenv('FINHUB_API_KEY')
         if not api_key:
-            raise ValueError("FINNHUB_API_KEY environment variable is required")
+            raise ValueError("FINHUB_API_KEY environment variable is required")
         return cls(api_key=api_key)
 
 


### PR DESCRIPTION
Updated all references to match the Vercel environment variable configuration. This ensures the application can access the Finnhub API key without requiring changes to the deployment configuration.

Changes:
- Updated pipeline/utils/config.py to read FINHUB_API_KEY
- Updated .env.example template
- Updated README.md environment variables table
- Updated EARNINGS_CALENDAR_SETUP.md documentation